### PR TITLE
Revert "Added the Destroy gui control method"

### DIFF
--- a/_GuiCtlExt.ahk
+++ b/_GuiCtlExt.ahk
@@ -245,16 +245,6 @@ class Edit_Ext extends Gui.Edit {
     }
 }
 
-class Edit_Control extends Gui.Control {
-    Static __New() {
-        For prop in this.Prototype.OwnProps()
-            super.Prototype.%prop% := this.prototype.%prop%
-    }
-    Destroy() {
-        DllCall("DestroyWindow", "UInt", this.hwnd)
-    }
-}
-
 ; ==================================================================
 ; Gui_Ext
 ; ==================================================================


### PR DESCRIPTION
Reverts TheArkive/GuiCtlExt_ahk2#2

Apologies I misread some stuff.  Can you add this method directly to the GuiControl object?  Instead of just a text control?

Specifically at the top of the main script is what I'm thinking:

```
class GuiCtl_Ext { ; apply common stuff to other gui controls
    Static __New() {
        Gui.ListBox.Prototype.GetItems := this.prototype.GetItems
        Gui.ListBox.Prototype._GetString := this.prototype._GetString
        Gui.ComboBox.Prototype.GetItems := this.prototype.GetItems
        Gui.ComboBox.Prototype._GetString := this.prototype._GetString
        
        Gui.Edit.Prototype._SetSel := this.prototype._SetSel
        Gui.Edit.Prototype._SelText := this.prototype._SelText
        Gui.ComboBox.Prototype._SetSel := this.prototype._SetSel
        Gui.ComboBox.Prototype._SelText := this.prototype._SelText
        
        ; Gui.GuiControl.Destroy := this.Prototype.Destroy ; ... and of course there needs to be a method below
    }
```

Please consider making another pull request with these changes.  As this is your idea, I'd rather not just add it myself.